### PR TITLE
Feature/efficient enumerator

### DIFF
--- a/TernaryTree/TernaryTree.cs
+++ b/TernaryTree/TernaryTree.cs
@@ -199,7 +199,7 @@ namespace TernaryTree
         /// <returns></returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return new TernaryTreeEnumerator<V>(this);
+            return new TernaryTreeEnumerator<V>(this, _head);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace TernaryTree
         /// <returns></returns>
         IEnumerator<KeyValuePair<string, V>> IEnumerable<KeyValuePair<string, V>>.GetEnumerator()
         {
-            return new TernaryTreeEnumerator<V>(this);
+            return new TernaryTreeEnumerator<V>(this, _head);
         }
 
         #endregion

--- a/TernaryTree/TernaryTreeEnumerator.cs
+++ b/TernaryTree/TernaryTreeEnumerator.cs
@@ -17,14 +17,16 @@ namespace TernaryTree
              */
 
         private delegate string Step();
-        private Stack<Step> _nextStep;
+        private Stack<Step> _nextStep = new Stack<Step>();
         private TernaryTree<V> _tree;
+        private Node<V> _head;
         private bool _isInitialized = false;
-        // TODO: Save current key as a field.
+        private string _currentKey;
 
-        public TernaryTreeEnumerator(TernaryTree<V> tree)
+        public TernaryTreeEnumerator(TernaryTree<V> tree, Node<V> head)
         {
             _tree = tree ?? throw new ArgumentNullException(nameof(tree));
+            _head = head ?? throw new ArgumentNullException(nameof(head));
         }
 
         /// <summary>
@@ -36,6 +38,11 @@ namespace TernaryTree
         /// Returns a <see cref="KeyValuePair{TKey, TValue}"/> with the current key and value.
         /// </summary>
         KeyValuePair<string, V> IEnumerator<KeyValuePair<string, V>>.Current => _currentValue();
+
+        private KeyValuePair<string, V> _currentValue()
+        {
+            return new KeyValuePair<string, V>(_currentKey, _head.Data);
+        }
 
         /// <summary>
         /// Does nothing.
@@ -54,16 +61,24 @@ namespace TernaryTree
         {
             if (!_isInitialized)
             {
-                // Need to change back to asking for _head on construction
+                Step firstStep = new Step(_createStep(_head, default(string)));
+                _nextStep.Push(firstStep);
+
             }
             string s = default(string);
             while(_nextStep.Count > 0 && string.IsNullOrEmpty(s))
             {
                 s = _nextStep.Pop().Invoke();
-                // save string to prepare return for Current
-                // return true;
             }
-            // if stack's empty and s is stil null, return false
+            if (!string.IsNullOrEmpty(s))
+            {
+                _currentKey = s;
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -91,7 +106,7 @@ namespace TernaryTree
                 }
                 if (node.IsFinalNode)
                 {
-                    Step s = new Step(_createStepCheckFinalNode(node, key + node.Value));
+                    Step s = new Step(_createStepReturnKey(node, key + node.Value));
                     _nextStep.Push(s);
                 }
                 if (node.Smaller != null)
@@ -104,15 +119,11 @@ namespace TernaryTree
             return f;
         }
 
-        private Func<string> _createStepCheckFinalNode(Node<V> node, string key)
+        private Func<string> _createStepReturnKey(Node<V> node, string key)
         {
             string f()
             {
-                if (node.IsFinalNode)
-                {
-                    return key;
-                }
-                return default(string);
+                return key;
             }
             return f;
         }

--- a/TernaryTree/TernaryTreeEnumerator.cs
+++ b/TernaryTree/TernaryTreeEnumerator.cs
@@ -81,22 +81,22 @@ namespace TernaryTree
             {
                 if (node.Bigger != null)
                 {
-                    Step s = _createStep(node.Bigger, key) as Step; // TODO: Why is this cast necesary? Doing something wrong?
+                    Step s = new Step(_createStep(node.Bigger, key));
                     _nextStep.Push(s);
                 }
                 if (node.Equal != null)
                 {
-                    Step s = _createStep(node.Equal, key + node.Value) as Step;
+                    Step s = new Step(_createStep(node.Equal, key + node.Value));
                     _nextStep.Push(s);
                 }
                 if (node.IsFinalNode)
                 {
-                    Step s = _createStepCheckFinalNode(node, key + node.Value) as Step;
+                    Step s = new Step(_createStepCheckFinalNode(node, key + node.Value));
                     _nextStep.Push(s);
                 }
                 if (node.Smaller != null)
                 {
-                    Step s = _createStep(node.Smaller, key) as Step;
+                    Step s = new Step(_createStep(node.Smaller, key));
                     _nextStep.Push(s);
                 }
                 return default(string);

--- a/TernaryTree/TernaryTreeEnumerator.cs
+++ b/TernaryTree/TernaryTreeEnumerator.cs
@@ -14,10 +14,13 @@ namespace TernaryTree
          Keep popping / searching until you find the next key.
          Then push the remaining state back on to the stack.
          (Also have to push every time you leave a Node with children to check.)
+
+            
              */
 
         private TernaryTree<V> _tree;
         private int _pos = -1;
+        // TODO: Add a stack, but don't initialize
 
         public TernaryTreeEnumerator(TernaryTree<V> tree)
         {
@@ -49,6 +52,8 @@ namespace TernaryTree
         /// <returns></returns>
         public bool MoveNext()
         {
+            // TODO: IF stack is null, put _head on the stack
+            // Otherwise, pop and search until you find the next valid key
             _pos++;
             // If we're already past the end, don't even try
             if (_pos > _tree.Count - 1)
@@ -66,6 +71,7 @@ namespace TernaryTree
         /// </summary>
         public void Reset()
         {
+            // TODO: Reset the stack to null
             // reset to BEFORE the first index (per Microsoft docs)
             _pos = -1;
         }

--- a/TernaryTree/TernaryTreeEnumerator.cs
+++ b/TernaryTree/TernaryTreeEnumerator.cs
@@ -40,9 +40,10 @@ namespace TernaryTree
         public void Dispose() { }
 
         /// <summary>
-        /// 
+        /// Moves to the next <see cref="KeyValuePair"/> in the enumeration.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Returns <code>true</code> if the next <see cref="KeyValuePair"/> was found.
+        /// Otherwise returns <code>false</code>.</returns>
         public bool MoveNext()
         {
             if (!_isInitialized)
@@ -72,7 +73,7 @@ namespace TernaryTree
         }
 
         /// <summary>
-        /// 
+        /// Resets the enumerator to before the first <see cref="KeyValuePair"/> in the enumeration.
         /// </summary>
         public void Reset()
         {

--- a/TernaryTree/TernaryTreeEnumerator.cs
+++ b/TernaryTree/TernaryTreeEnumerator.cs
@@ -30,12 +30,6 @@ namespace TernaryTree
         /// </summary>
         KeyValuePair<string, V> IEnumerator<KeyValuePair<string, V>>.Current => _currentValue();
 
-        private KeyValuePair<string, V> _currentValue()
-        {
-            _tree.TryGetValue(_currentKey, out V value);
-            return new KeyValuePair<string, V>(_currentKey, value);
-        }
-
         /// <summary>
         /// Does nothing.
         /// </summary>
@@ -84,6 +78,12 @@ namespace TernaryTree
         {
             _nextStep.Clear();
             _isInitialized = false;
+        }
+
+        private KeyValuePair<string, V> _currentValue()
+        {
+            _tree.TryGetValue(_currentKey, out V value);
+            return new KeyValuePair<string, V>(_currentKey, value);
         }
 
         private Func<string> _createStep(Node<V> node, string key)

--- a/TernaryTreeTest/EnumeratorTest.cs
+++ b/TernaryTreeTest/EnumeratorTest.cs
@@ -16,18 +16,25 @@ namespace TernaryTreeTest
             new KeyValuePair<string, int>( "four", 4)
         };
 
+        private readonly ICollection<KeyValuePair<string, int>> _sortedKeyValueCollection = new List<KeyValuePair<string, int>>
+        {
+            new KeyValuePair<string, int>("four", 4),
+            new KeyValuePair<string, int>("one", 1),
+            new KeyValuePair<string, int>("three", 3),
+            new KeyValuePair<string, int>("two", 2),
+            new KeyValuePair<string, int>("zero", 0)
+        };
+
         [Test]
-        public void Enumerator_Returns_Keys_In_Order()
+        public void Enumerator_Returns_All_Elements_In_Order()
         {
             TernaryTree<int> subject = TernaryTree<int>.Create(_keyValueCollection);
-            Assert.Multiple(() => 
+            List<KeyValuePair<string, int>> actualResult = new List<KeyValuePair<string, int>>();
+            foreach (KeyValuePair<string, int> kvPair in subject)
             {
-                foreach (KeyValuePair<string, int> kvPair in subject)
-                {
-                    // TODO: Actually check that the enumerator returns elements in order / returns all elements
-                    Assert.That(_keyValueCollection.Contains(kvPair));
-                }
-            });
+                actualResult.Add(kvPair);
+            }
+            Assert.That(actualResult, Is.EqualTo(_sortedKeyValueCollection));
         }
     }
 }


### PR DESCRIPTION
This PR changes the enumerator to avoid calling the expensive indexer.
This is accomplished by creating an artificial call stack of delegates to be held by the enumerator, so that the enumerator can freeze traversal through the tree while returning execution.