### PR TITLE
Better tests for regex matching

### DIFF
--- a/TernaryTree/TernaryTree.cs
+++ b/TernaryTree/TernaryTree.cs
@@ -8,8 +8,8 @@ namespace TernaryTree
     // TODO: Logging?
     // TODO: Error Handling and Documentation.  Follow Microsoft lead with interfaces.
     // TODO: More unit tests.  Check line coverage.
-    // TODO: What if you try to add a string with whitespace or line-ending characters?
-    // TODO: If we stored a KeyValuePair at Node.Data, we could do away with all the string building.
+    // TODO: What if you try to add a string with line-ending (or other special) characters?
+    // TODO: If we stored a KeyValuePair at Node.Data, we could do away with all the string building. Is this preferrable?
 
     /// <summary>
     /// Provides a structure for storing key value pairs.

--- a/TernaryTree/TernaryTreeSearch.cs
+++ b/TernaryTree/TernaryTreeSearch.cs
@@ -36,6 +36,7 @@ namespace TernaryTree
         /// <returns></returns>
         public ICollection<string> Match(Node<V> head)
         {
+            _ = head ?? throw new ArgumentNullException(nameof(head));
             _getBranchMatches(head, default(string));
             return _matches;
         }
@@ -89,12 +90,6 @@ namespace TernaryTree
                     pos = _handleBrackets(pos, pattern, successState);
                     break;
                 //case '{':
-                //TODO: Handle grouping.
-                //pos = _handleGroup(pos, pattern);
-                //continue;
-                //case ']':
-                //case ')':
-                //case '}':
                 default:
                     pos = _handleLiteral(pos, pattern, successState);
                     break;

--- a/TernaryTree/TernaryTreeSearch.cs
+++ b/TernaryTree/TernaryTreeSearch.cs
@@ -112,7 +112,6 @@ namespace TernaryTree
             return ++pos;
         }
 
-        // TODO: Fix star repeating
         private int _handleStar(int pos, string pattern)
         {
             // TODO: Throw some kind of syntax error (ArgumentException?) if star is in the first position.  (There's nothing to repeat.)
@@ -168,6 +167,7 @@ namespace TernaryTree
         private int _handleBrackets(int pos, string pattern, int successState)
         {
             // TODO: If pos is last character throw error
+            int startPos = pos;
             bool isNegativeQuery = false;
             bool isRangeQuery = false;
             LinkedList<char> matchingChars = new LinkedList<char>();
@@ -214,7 +214,7 @@ namespace TernaryTree
             {
                 _transitions[_state].Add(new Transition(_matchAnyOf(matchingChars, successState)));
             }
-            // TODO: how are we going to handle _lastSymbol?
+            _lastSymbol = pattern.Substring(startPos, pos - startPos + 1);
             return ++pos;
         }
         
@@ -302,11 +302,12 @@ namespace TernaryTree
 
         private Func<Node<V>, string, int> _checkValidKeyDecorator(Transition t) => (node, key) => 
         {
-            if (node.IsFinalNode)
+            int newState = t.Invoke(node, key);
+            if (newState > -1 && node.IsFinalNode)
             {
                 _matches.Add(key + node.Value);
             }
-            return t.Invoke(node, key);
+            return newState;
         };
 
         private Func<Node<V>, string, int> _matchEverything(int successState) => (node, key) => successState;

--- a/TernaryTreeTest/TernaryTreeSearchTest.cs
+++ b/TernaryTreeTest/TernaryTreeSearchTest.cs
@@ -73,10 +73,6 @@ namespace TernaryTreeTest
                 {
                     Assert.That(actualResult.Contains(key));
                 }
-                foreach (string nonMatchingKey in nonMatchingKeys)
-                {
-                    Assert.IsFalse(actualResult.Contains(nonMatchingKey));
-                }
             });
         }
 
@@ -150,10 +146,6 @@ namespace TernaryTreeTest
                 {
                     Assert.That(actualResult.Contains(key));
                 }
-                foreach (string nonMatchingKey in nonMatchingKeys)
-                {
-                    Assert.IsFalse(actualResult.Contains(nonMatchingKey));
-                }
             });
         }
 
@@ -174,10 +166,6 @@ namespace TernaryTreeTest
                 foreach (string key in matchingKeys)
                 {
                     Assert.That(actualResult.Contains(key));
-                }
-                foreach (string nonMatchingKey in nonMatchingKeys)
-                {
-                    Assert.IsFalse(actualResult.Contains(nonMatchingKey));
                 }
             });
         }
@@ -200,10 +188,6 @@ namespace TernaryTreeTest
                 {
                     Assert.That(actualResult.Contains(key));
                 }
-                foreach (string nonMatchingKey in nonMatchingKeys)
-                {
-                    Assert.IsFalse(actualResult.Contains(nonMatchingKey));
-                }
             });
         }
 
@@ -223,10 +207,6 @@ namespace TernaryTreeTest
                 foreach (string key in matchingKeys)
                 {
                     Assert.That(actualResult.Contains(key));
-                }
-                foreach (string nonMatchingKey in nonMatchingKeys)
-                {
-                    Assert.IsFalse(actualResult.Contains(nonMatchingKey));
                 }
             });
         }

--- a/TernaryTreeTest/TernaryTreeSearchTest.cs
+++ b/TernaryTreeTest/TernaryTreeSearchTest.cs
@@ -8,12 +8,7 @@ namespace TernaryTreeTest
     // TODO: Every test has the same body.  Should there only be a single test method with 100+ test cases?
     class TernaryTreeSearchTest
     {
-        [TestCase("zero", new string[] { "zero" }, new string[] { "one", "two", "three", "four" })]
-        [TestCase("one", new string[] { "one" }, new string[] { "zero", "two", "three", "four" })]
-        [TestCase("two", new string[] { "two" }, new string[] { "zero", "one", "three", "four" })]
-        [TestCase("three", new string[] { "three" }, new string[] { "zero", "one", "two", "four" })]
-        [TestCase("four", new string[] { "four" }, new string[] { "zero", "one", "two", "three" })]
-        public void Exact_Match(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
+        public void Regex_Match_Test(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
             TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
             foreach (string nonMatchingKey in nonMatchingKeys)
@@ -30,6 +25,16 @@ namespace TernaryTreeTest
                     Assert.That(actualResult.Contains(key));
                 }
             });
+        }
+
+        [TestCase("zero", new string[] { "zero" }, new string[] { "one", "two", "three", "four" })]
+        [TestCase("one", new string[] { "one" }, new string[] { "zero", "two", "three", "four" })]
+        [TestCase("two", new string[] { "two" }, new string[] { "zero", "one", "three", "four" })]
+        [TestCase("three", new string[] { "three" }, new string[] { "zero", "one", "two", "four" })]
+        [TestCase("four", new string[] { "four" }, new string[] { "zero", "one", "two", "three" })]
+        public void Exact_Match(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
+        {
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
 
         [TestCase(".ero", new string[] { "zero", "hero", "nero" }, new string[] { "none", "of", "these" })]
@@ -39,21 +44,7 @@ namespace TernaryTreeTest
         [TestCase("f...", new string[] { "four", "foot", "flip" }, new string[] { "flashy", "freaking", "fools" })]
         public void Wildcard_Match(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
-            foreach (string nonMatchingKey in nonMatchingKeys)
-            {
-                subject.Add(nonMatchingKey);
-            }
-            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
-            Assert.Multiple(() =>
-            {
-                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
-                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
-                foreach (string key in matchingKeys)
-                {
-                    Assert.That(actualResult.Contains(key));
-                }
-            });
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
 
         [TestCase("ab*a", new string[] { "abbbbbba", "aba", "aa" }, new string[] { "abca", "ab", "ba" })]
@@ -62,21 +53,7 @@ namespace TernaryTreeTest
         [TestCase("ab*c", new string[] { "abbbbbbbbc", "abc", "ac" }, new string[] { "acb", "cab", "bca" })]
         public void Repeating_Literal(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
-            foreach (string nonMatchingKey in nonMatchingKeys)
-            {
-                subject.Add(nonMatchingKey);
-            }
-            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
-            Assert.Multiple(() =>
-            {
-                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
-                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
-                foreach (string key in matchingKeys)
-                {
-                    Assert.That(actualResult.Contains(key));
-                }
-            });
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
 
         [TestCase("a.*a", new string[] { "aa", "aba", "abca", "abbbcbcbccccbba" }, new string[] { "a", "ab", "ba", "abc" })]
@@ -84,41 +61,13 @@ namespace TernaryTreeTest
         [TestCase("a.*", new string[] { "a", "ab", "abcbccbcbccbbbcbc" }, new string[] { "b", "ba", "baaaa" })]
         public void Repeating_Dot(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
-            foreach (string nonMatchingKey in nonMatchingKeys)
-            {
-                subject.Add(nonMatchingKey);
-            }
-            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
-            Assert.Multiple(() =>
-            {
-                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
-                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
-                foreach (string key in matchingKeys)
-                {
-                    Assert.That(actualResult.Contains(key));
-                }
-            });
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
 
         [TestCase("th.*", new string[] { "this", "these", "those" }, new string[] { "nothing", "in", "here" })]
         public void Prefix_Exact(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
-            foreach (string nonMatchingKey in nonMatchingKeys)
-            {
-                subject.Add(nonMatchingKey);
-            }
-            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
-            Assert.Multiple(() =>
-            {
-                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
-                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
-                foreach (string key in matchingKeys)
-                {
-                    Assert.That(actualResult.Contains(key));
-                }
-            });
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
 
         [TestCase(".*a.*", new string[] { "a", "ba", "ac", "bbbbbbbbbbbbbbbacccccccccccccc" }, new string[] { "none", "of", "these" })]
@@ -126,63 +75,21 @@ namespace TernaryTreeTest
         [TestCase(".*first.*second.*third.*", new string[] { "xxx_first_xxx_second_xxx_third_xxx", "firstsecondthird", "first; second; third" }, new string[] { "third", "this ain't it", "first" })]
         public void Contains_Exact(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
-            foreach (string nonMatchingKey in nonMatchingKeys)
-            {
-                subject.Add(nonMatchingKey);
-            }
-            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
-            Assert.Multiple(() =>
-            {
-                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
-                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
-                foreach (string key in matchingKeys)
-                {
-                    Assert.That(actualResult.Contains(key));
-                }
-            });
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
 
         [TestCase("[a-z]", new string[] { "a", "b", "c", "d", "e" }, new string[] { "A", "B", "C", "D", "E" })]
         [TestCase("[A-Z][0-9]", new string[] { "A0", "B1", "C2", "D3", "E4" }, new string[] { "9A", "BB", "AC", "6D", "a1" })]
         public void Range(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
-            foreach (string nonMatchingKey in nonMatchingKeys)
-            {
-                subject.Add(nonMatchingKey);
-            }
-            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
-            Assert.Multiple(() => 
-            {
-                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
-                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
-                foreach (string key in matchingKeys)
-                {
-                    Assert.That(actualResult.Contains(key));
-                }
-            });
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
 
         [TestCase("[^0-9]", new string[] { "a", "b", "c", "d", "e" }, new string[] { "0", "1", "2", "3", "4" })]
         [TestCase("[^a-z]", new string[] { "0", "1", "2", "3", "4" }, new string[] { "a", "b", "c", "d", "e" })]
         public void Any_But_Range(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
-            foreach (string nonMatchingKey in nonMatchingKeys)
-            {
-                subject.Add(nonMatchingKey);
-            }
-            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
-            Assert.Multiple(() =>
-            {
-                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
-                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
-                foreach (string key in matchingKeys)
-                {
-                    Assert.That(actualResult.Contains(key));
-                }
-            });
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
 
         [TestCase("[AaBbCc]", new string[] { "A", "a", "B", "b", "C", "c" }, new string[] { "D", "d", "E", "e", "F", "f" })]
@@ -190,41 +97,13 @@ namespace TernaryTreeTest
         [TestCase("[Ll1][Ee3][Ee3][Tt7]", new string[] { "1337", "leet", "LEET", "13eT" }, new string[] { "Elite", "lite", "leat", "light" })]
         public void Character_Group(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
-            foreach (string nonMatchingKey in nonMatchingKeys)
-            {
-                subject.Add(nonMatchingKey);
-            }
-            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
-            Assert.Multiple(() =>
-            {
-                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
-                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
-                foreach (string key in matchingKeys)
-                {
-                    Assert.That(actualResult.Contains(key));
-                }
-            });
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
 
         [TestCase("[^Aa]", new string[] { "B", "b" }, new string[] { "A", "a" })]
         public void Any_But_Group(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
-            foreach (string nonMatchingKey in nonMatchingKeys)
-            {
-                subject.Add(nonMatchingKey);
-            }
-            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
-            Assert.Multiple(() =>
-            {
-                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
-                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
-                foreach (string key in matchingKeys)
-                {
-                    Assert.That(actualResult.Contains(key));
-                }
-            });
+            Regex_Match_Test(pattern, matchingKeys, nonMatchingKeys);
         }
     }
 }

--- a/TernaryTreeTest/TernaryTreeSearchTest.cs
+++ b/TernaryTreeTest/TernaryTreeSearchTest.cs
@@ -5,51 +5,54 @@ using TernaryTree;
 
 namespace TernaryTreeTest
 {
-    // TODO: add 'nonMatchingKeys' parameter to all tests and assert that actual results do not contain
+    // TODO: Every test has the same body.  Should there only be a single test method with 100+ test cases?
     class TernaryTreeSearchTest
     {
-        private readonly ICollection<KeyValuePair<string, int>> _keyValueCollection = new List<KeyValuePair<string, int>>
+        [TestCase("zero", new string[] { "zero" }, new string[] { "one", "two", "three", "four" })]
+        [TestCase("one", new string[] { "one" }, new string[] { "zero", "two", "three", "four" })]
+        [TestCase("two", new string[] { "two" }, new string[] { "zero", "one", "three", "four" })]
+        [TestCase("three", new string[] { "three" }, new string[] { "zero", "one", "two", "four" })]
+        [TestCase("four", new string[] { "four" }, new string[] { "zero", "one", "two", "three" })]
+        public void Exact_Match(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            new KeyValuePair<string, int>("zero", 0),
-            new KeyValuePair<string, int>("one", 1),
-            new KeyValuePair<string, int>("two", 2),
-            new KeyValuePair<string, int>("three", 3),
-            new KeyValuePair<string, int>("four", 4)
-        };
-
-        [TestCase("zero")]
-        [TestCase("one")]
-        [TestCase("two")]
-        [TestCase("three")]
-        [TestCase("four")]
-        public void Exact_Match(string matchKey)
-        {
-            TernaryTree<int> subject = TernaryTree<int>.Create(_keyValueCollection);
-            ICollection<string> actualResult = subject.Match(matchKey);
-            string[] resultArray = new string[actualResult.Count];
-            actualResult.CopyTo(resultArray, 0);
+            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
+            foreach (string nonMatchingKey in nonMatchingKeys)
+            {
+                subject.Add(nonMatchingKey);
+            }
+            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
             Assert.Multiple(() =>
             {
-                Assert.That(resultArray.Length, Is.EqualTo(1));
-                Assert.That(resultArray[0], Is.EqualTo(matchKey));
+                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
+                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
+                foreach (string key in matchingKeys)
+                {
+                    Assert.That(actualResult.Contains(key));
+                }
             });
         }
 
-        [TestCase(".ero", "zero")]
-        [TestCase("o.e", "one")]
-        [TestCase(".w.", "two")]
-        [TestCase("t...e", "three")]
-        [TestCase("f...", "four")]
-        public void Wildcard_Match(string pattern, string expectedResult)
+        [TestCase(".ero", new string[] { "zero", "hero", "nero" }, new string[] { "none", "of", "these" })]
+        [TestCase("o.e", new string[] { "one", "ole", "owe" }, new string[] { "own", "nose", "oreo" })]
+        [TestCase(".w.", new string[] { "two", "ewe", "awe" }, new string[] { "tweed", "goo", "swoop" })]
+        [TestCase("t...e", new string[] { "three", "twice", "trove" }, new string[] { "I", "don't", "know" })]
+        [TestCase("f...", new string[] { "four", "foot", "flip" }, new string[] { "flashy", "freaking", "fools" })]
+        public void Wildcard_Match(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(_keyValueCollection);
-            ICollection<string> actualResult = subject.Match(pattern);
-            string[] resultArray = new string[actualResult.Count];
-            actualResult.CopyTo(resultArray, 0);
+            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
+            foreach (string nonMatchingKey in nonMatchingKeys)
+            {
+                subject.Add(nonMatchingKey);
+            }
+            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
             Assert.Multiple(() =>
             {
-                Assert.That(resultArray.Length, Is.EqualTo(1));
-                Assert.That(resultArray[0], Is.EqualTo(expectedResult));
+                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
+                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
+                foreach (string key in matchingKeys)
+                {
+                    Assert.That(actualResult.Contains(key));
+                }
             });
         }
 
@@ -76,54 +79,67 @@ namespace TernaryTreeTest
             });
         }
 
-        [TestCase("a.*a", "abbbcbcccbcbcbbbcccbba")]
-        [TestCase(".*a", "bcbcccbcbcbbbcbcbcccbcbbbbcbcbcba")]
-        [TestCase("a.*", "abcbcbcbcbcbcbcbcbcbbcccbcbcbccbbbcbc")]
-        [TestCase("a.*", "a")]
-        [TestCase("a.*c", "ac")]
-        public void Repeating_Dot(string pattern, string expectedResult)
+        [TestCase("a.*a", new string[] { "aa", "aba", "abca", "abbbcbcbccccbba" }, new string[] { "a", "ab", "ba", "abc" })]
+        [TestCase(".*a", new string[] { "a", "ba", "bcbcccbcbcbbcbcbbbbcbcbcba" }, new string[] { "b", "ab", "cab" })]
+        [TestCase("a.*", new string[] { "a", "ab", "abcbccbcbccbbbcbc" }, new string[] { "b", "ba", "baaaa" })]
+        public void Repeating_Dot(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(_keyValueCollection);
-            subject.Add(expectedResult);
-            ICollection<string> actualResult = subject.Match(pattern);
-            string[] resultArray = new string[actualResult.Count];
-            actualResult.CopyTo(resultArray, 0);
+            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
+            foreach (string nonMatchingKey in nonMatchingKeys)
+            {
+                subject.Add(nonMatchingKey);
+            }
+            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
             Assert.Multiple(() =>
             {
-                Assert.That(resultArray.Length, Is.EqualTo(1));
-                Assert.That(resultArray[0], Is.EqualTo(expectedResult));
+                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
+                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
+                foreach (string key in matchingKeys)
+                {
+                    Assert.That(actualResult.Contains(key));
+                }
             });
         }
 
-        [Test]
-        public void Prefix_Exact()
+        [TestCase("th.*", new string[] { "this", "these", "those" }, new string[] { "nothing", "in", "here" })]
+        public void Prefix_Exact(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(_keyValueCollection);
-            ICollection<string> actualResult = subject.Match("t.*");
-            string[] resultArray = new string[actualResult.Count];
-            actualResult.CopyTo(resultArray, 0);
-            Assert.Multiple(() => 
+            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
+            foreach (string nonMatchingKey in nonMatchingKeys)
             {
-                Assert.That(resultArray.Length, Is.EqualTo(2));
-                Assert.That(resultArray[0], Is.EqualTo("three"));
-                Assert.That(resultArray[1], Is.EqualTo("two"));
+                subject.Add(nonMatchingKey);
+            }
+            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
+            Assert.Multiple(() =>
+            {
+                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
+                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
+                foreach (string key in matchingKeys)
+                {
+                    Assert.That(actualResult.Contains(key));
+                }
             });
         }
 
-        [TestCase(".*a.*", "bbbbbbbbbbbbbbbacccccccccccccc")]
-        [TestCase(".*test_case.*", "this can be anything __ test_case ___ ")]
-        [TestCase(".*first.*second.*third.*", "xxx_first_xxx_second_xxx_third_xxx")]
-        public void Contains_Exact(string pattern, string matchingKey)
+        [TestCase(".*a.*", new string[] { "a", "ba", "ac", "bbbbbbbbbbbbbbbacccccccccccccc" }, new string[] { "none", "of", "these" })]
+        [TestCase(".*test.*", new string[] { "test_this", "this is the test", "this test" }, new string[] { "tes", "est", "best" })]
+        [TestCase(".*first.*second.*third.*", new string[] { "xxx_first_xxx_second_xxx_third_xxx", "firstsecondthird", "first; second; third" }, new string[] { "third", "this ain't it", "first" })]
+        public void Contains_Exact(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(_keyValueCollection);
-            subject.Add(matchingKey);
-            ICollection<string> actualResult = subject.Match(pattern);
-            string[] resultArray = new string[actualResult.Count];
-            actualResult.CopyTo(resultArray, 0);
+            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
+            foreach (string nonMatchingKey in nonMatchingKeys)
+            {
+                subject.Add(nonMatchingKey);
+            }
+            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
             Assert.Multiple(() =>
             {
-                Assert.That(resultArray.Length, Is.EqualTo(1));
-                Assert.That(resultArray[0], Is.EqualTo(matchingKey));
+                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
+                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
+                foreach (string key in matchingKeys)
+                {
+                    Assert.That(actualResult.Contains(key));
+                }
             });
         }
 
@@ -131,7 +147,6 @@ namespace TernaryTreeTest
         [TestCase("[0-9]", new string[] { "0", "1", "2", "3", "4" }, new string[] { "A", "B", "C", "D", "E" })]
         public void Range(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            // TODO: All the range tests use the same test body.  Should they be combined into a single method?
             TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
             foreach (string nonMatchingKey in nonMatchingKeys)
             {

--- a/TernaryTreeTest/TernaryTreeSearchTest.cs
+++ b/TernaryTreeTest/TernaryTreeSearchTest.cs
@@ -53,22 +53,31 @@ namespace TernaryTreeTest
             });
         }
 
-        [TestCase("ab*a", "abbbbbba")]
-        [TestCase("a*b", "aaaaaaaab")]
-        [TestCase("ab*", "abbbbbbbb")]
-        [TestCase("ab*c", "ac")]
-        [TestCase("ab*", "a")]
-        public void Repeating_Literal(string pattern, string expectedResult)
+        [TestCase("ab*a", new string[] { "abbbbbba", "aba", "aa" }, new string[] { "abca", "ab", "ba" })]
+        [TestCase("a*b", new string[] { "aaaaaaaab", "ab", "b" }, new string[] { "acb", "cab", "ba"})]
+        [TestCase("ab*", new string[] { "abbbbbbbb", "ab", "a" }, new string[] { "acb", "ba", "abc" })]
+        [TestCase("ab*c", new string[] { "abbbbbbbbc", "abc", "ac" }, new string[] { "acb", "cab", "bca" })]
+        [TestCase("ab*", new string[] { "a", "ab", "abbbb" }, new string[] { "b", "ba", "bbbbba" })]
+        public void Repeating_Literal(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
-            TernaryTree<int> subject = TernaryTree<int>.Create(_keyValueCollection);
-            subject.Add(expectedResult);
-            ICollection<string> actualResult = subject.Match(pattern);
-            string[] resultArray = new string[actualResult.Count];
-            actualResult.CopyTo(resultArray, 0);
+            TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
+            foreach (string nonMatchingKey in nonMatchingKeys)
+            {
+                subject.Add(nonMatchingKey);
+            }
+            HashSet<string> actualResult = new HashSet<string>(subject.Match(pattern));
             Assert.Multiple(() =>
             {
-                Assert.That(resultArray.Length, Is.EqualTo(1));
-                Assert.That(resultArray[0], Is.EqualTo(expectedResult));
+                Assert.That(subject.Count, Is.EqualTo(matchingKeys.Length + nonMatchingKeys.Length));
+                Assert.That(actualResult.Count, Is.EqualTo(matchingKeys.Length));
+                foreach (string key in matchingKeys)
+                {
+                    Assert.That(actualResult.Contains(key));
+                }
+                foreach (string nonMatchingKey in nonMatchingKeys)
+                {
+                    Assert.IsFalse(actualResult.Contains(nonMatchingKey));
+                }
             });
         }
 

--- a/TernaryTreeTest/TernaryTreeSearchTest.cs
+++ b/TernaryTreeTest/TernaryTreeSearchTest.cs
@@ -55,9 +55,8 @@ namespace TernaryTreeTest
 
         [TestCase("ab*a", new string[] { "abbbbbba", "aba", "aa" }, new string[] { "abca", "ab", "ba" })]
         [TestCase("a*b", new string[] { "aaaaaaaab", "ab", "b" }, new string[] { "acb", "cab", "ba"})]
-        [TestCase("ab*", new string[] { "abbbbbbbb", "ab", "a" }, new string[] { "acb", "ba", "abc" })]
+        [TestCase("ab*", new string[] { "abbbbbbbb", "ab", "a" }, new string[] { "b", "acb", "ba", "abc" })]
         [TestCase("ab*c", new string[] { "abbbbbbbbc", "abc", "ac" }, new string[] { "acb", "cab", "bca" })]
-        [TestCase("ab*", new string[] { "a", "ab", "abbbb" }, new string[] { "b", "ba", "bbbbba" })]
         public void Repeating_Literal(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
             TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);

--- a/TernaryTreeTest/TernaryTreeSearchTest.cs
+++ b/TernaryTreeTest/TernaryTreeSearchTest.cs
@@ -122,7 +122,7 @@ namespace TernaryTreeTest
         }
 
         [TestCase(".*a.*", new string[] { "a", "ba", "ac", "bbbbbbbbbbbbbbbacccccccccccccc" }, new string[] { "none", "of", "these" })]
-        [TestCase(".*test.*", new string[] { "test_this", "this is the test", "this test" }, new string[] { "tes", "est", "best" })]
+        [TestCase(".*test.*", new string[] { "test_this", "this is the test", "this test right here" }, new string[] { "tes", "est", "best" })]
         [TestCase(".*first.*second.*third.*", new string[] { "xxx_first_xxx_second_xxx_third_xxx", "firstsecondthird", "first; second; third" }, new string[] { "third", "this ain't it", "first" })]
         public void Contains_Exact(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
@@ -144,7 +144,7 @@ namespace TernaryTreeTest
         }
 
         [TestCase("[a-z]", new string[] { "a", "b", "c", "d", "e" }, new string[] { "A", "B", "C", "D", "E" })]
-        [TestCase("[0-9]", new string[] { "0", "1", "2", "3", "4" }, new string[] { "A", "B", "C", "D", "E" })]
+        [TestCase("[A-Z][0-9]", new string[] { "A0", "B1", "C2", "D3", "E4" }, new string[] { "9A", "BB", "AC", "6D", "a1" })]
         public void Range(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
             TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);
@@ -187,6 +187,7 @@ namespace TernaryTreeTest
 
         [TestCase("[AaBbCc]", new string[] { "A", "a", "B", "b", "C", "c" }, new string[] { "D", "d", "E", "e", "F", "f" })]
         [TestCase("[ABCDE][12345]", new string[] { "A1", "B2", "C3", "D4", "E5" }, new string[] { "F6", "G7", "H8", "I9", "J0" })]
+        [TestCase("[Ll1][Ee3][Ee3][Tt7]", new string[] { "1337", "leet", "LEET", "13eT" }, new string[] { "Elite", "lite", "leat", "light" })]
         public void Character_Group(string pattern, string[] matchingKeys, string[] nonMatchingKeys)
         {
             TernaryTree<int> subject = TernaryTree<int>.Create(matchingKeys);


### PR DESCRIPTION
This PR simplifies the TernaryTreeSearchTest class and adds additional tests.
- All regex match tests now call a single method.
- Additional test cases can be added as features are implemented.
- New tests identified a bug (ab* matches b)
- This PR also fixes the above bug.